### PR TITLE
Fix API consistency

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -38,12 +38,13 @@ function mod (githubContext, githubToken) {
     return currentUserData
   }
 
-  async function findIssues ({ title, number, author = currentAuthor }) {
+  async function findIssues ({ titleIncludes, number, status, author = currentAuthor }) {
     // https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests
     let q = `is:issue repo:${fullName}`
-    if (title) q += ` in:title ${title}`
+    if (titleIncludes) q += ` in:title ${titleIncludes}`
     if (number) q += ` number:${number}`
     if (author) q += ` author:${author}`
+    if (status) q += ` is:${status}`
     debug(`Searching issues with query [${q}]`)
     const existingIssues = await octokit.rest.search.issuesAndPullRequests({ q })
     debug('Existing issues', q, existingIssues)
@@ -132,12 +133,14 @@ function mod (githubContext, githubToken) {
 
   async function findPullRequests ({
     titleIncludes,
+    number,
     author = currentAuthor,
     status = 'open'
   }) {
     // https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests
     let q = `is:pr repo:${fullName}`
     if (titleIncludes) q += ` in:title ${titleIncludes}`
+    if (number) q += ` number:${number}`
     if (author) q += ` author:${author}`
     if (status) q += ` is:${status}`
     debug(`Searching issues with query [${q}]`)

--- a/src/github.js
+++ b/src/github.js
@@ -56,19 +56,15 @@ function mod (githubContext, githubToken) {
       url: issue.html_url,
       author: issue.user.login,
       body: issue.body,
-      created: issue.created_at
+      created: issue.created_at,
+      isOpen: issue.state === 'open',
+      isClosed: issue.state === 'closed'
     }))
   }
 
-  async function getIssueStatus (options) {
+  async function findIssue (options) {
     const existingIssues = await findIssues(options)
-    const existingIssue = existingIssues[0]
-    if (!existingIssue) return {}
-    return {
-      ...existingIssue,
-      open: existingIssue.state === 'open',
-      closed: existingIssue.state === 'closed'
-    }
+    return existingIssues[0]
   }
 
   async function updateIssue (id, payload) {
@@ -156,20 +152,15 @@ function mod (githubContext, githubToken) {
       url: issue.html_url,
       author: issue.user.login,
       body: issue.body,
-      created: issue.created_at
+      created: issue.created_at,
+      isOpen: issue.state === 'open',
+      isClosed: issue.state === 'closed'
     }))
   }
 
   async function findPullRequest (options) {
-    const pull = await findPullRequests(options)
-    const existingPull = pull[0]
-    if (!existingPull) return {}
-    debug('Found PR #', existingPull.number)
-    return {
-      ...existingPull,
-      open: existingPull.state === 'open',
-      closed: existingPull.state === 'closed'
-    }
+    const pulls = await findPullRequests(options)
+    return pulls[0]
   }
 
   async function updatePull (id, { title, body }) {
@@ -367,10 +358,11 @@ function mod (githubContext, githubToken) {
     getRepoDetails,
     getDefaultBranch,
     getInput,
-    getIssueStatus,
-    getComments,
 
     findIssues,
+    findIssue,
+    getComments,
+
     findPullRequests,
     findPullRequest,
     getPullRequest,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,7 +56,9 @@ type IssuePRDetail = {
   url: string,
   author: string,
   body: string,
-  created: string
+  created: string,
+  isOpen: boolean,
+  isClosed: boolean
 }
 
 interface GithubHelper {
@@ -84,8 +86,7 @@ interface GithubHelper {
   getInput(name: string, required?: boolean): string;
 
   findIssues(options: PRLookupOpt): Promise<IssuePRDetail[]>
-  findIssue(options: PRLookupOpt): Promise<IssuePRDetail
-    & { open: boolean, closed: boolean, id?: number }>
+  findIssue(options: PRLookupOpt): Promise<IssuePRDetail>
 
   updateIssue(id: number, payload: { body: string }): Promise<void>;
   createIssue(payload: object): Promise<void>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,7 +1,5 @@
 // Core methods
 
-type IssueStatus = { open: boolean; closed: boolean; id?: number };
-
 type Comment = {
   id: number,
   author: string,
@@ -86,7 +84,8 @@ interface GithubHelper {
   getInput(name: string, required?: boolean): string;
 
   findIssues(options: PRLookupOpt): Promise<IssuePRDetail[]>
-  getIssueStatus(options: PRLookupOpt): Promise<IssuePRDetail & IssueStatus>;
+  findIssue(options: PRLookupOpt): Promise<IssuePRDetail
+    & { open: boolean, closed: boolean, id?: number }>
 
   updateIssue(id: number, payload: { body: string }): Promise<void>;
   createIssue(payload: object): Promise<void>;
@@ -94,9 +93,11 @@ interface GithubHelper {
   findPullRequests(options: PRLookupOpt): Promise<IssuePRDetail[]>;
   findPullRequest(options: PRLookupOpt): Promise<IssuePRDetail>;
 
-  getComments(id: number): Promise<Comments[]>;
+  getComments(id: number): Promise<Comment[]>;
 
+  // Get full details about a PR by ID
   getPullRequest(id: number, includeComments?: boolean): Promise<FullPRData>;
+
   updatePull(id: number, payload: { title?: string; body?: string }): Promise<void>;
   createPullRequest(title: string, body: string, fromBranch: string, intoBranch?: string): Promise<{ number: number, url: string }>;
   createPullRequestReview(id: number, payload: {
@@ -107,6 +108,7 @@ interface GithubHelper {
   }): Promise<void>;
 
   close(id: number, reason?: string): Promise<void>;
+
   // Comment on an issue or PR
   comment(id: number, body: string): Promise<void>;
   // Comment on a commit hash
@@ -119,7 +121,9 @@ interface GithubHelper {
   getDiffForCommit(hash: string): Promise<{ diff: string, url: string }>
 
   // Sends a workflow dispatch request to the specified owner/repo's $workflow.yml file, with the specified inputs
-  sendWorkflowDispatch (arg: { owner: string, repo: string, workflow: string, branch: string, inputs: Record<string, string> }): void
+  sendWorkflowDispatch(arg: { owner: string, repo: string, workflow: string, branch: string, inputs: Record<string, string> }): void
+
+  // Events
 
   onRepoComment(fn: (payload: RepoCommentPayload, rawPayload: any) => void): void;
   onUpdatedPR(fn: (payload: UpdatedPRPayload) => void): void;
@@ -141,9 +145,9 @@ interface GithubHelper {
 
 // If the module is instantiated within Github Actions, all the needed info
 // is avaliable over environment variables
-function loader(): GithubHelper
+declare function loader(): GithubHelper
 // If the module is instantiated outside Actions over API, you need to supply
 // repo context + a Github personal access token (PAT)
-function loader(context: { repo: { owner: string, name: string } }, githubToken?: string): GithubHelper
+declare function loader(context: { repo: { owner: string, name: string } }, githubToken?: string): GithubHelper
 
 export = loader

--- a/src/mock.js
+++ b/src/mock.js
@@ -51,7 +51,7 @@ const mock = {
   getInput: noop,
 
   findIssues: () => [],
-  getIssueStatus: noop,
+  findIssue: noop,
 
   updateIssue: noop,
   createIssue: noop,


### PR DESCRIPTION
* Breaking: remove `.getIssueStatus()` in favor of `.findIssue()`
* Breaking: rename `.findIssue({ title })` in favor of `.findIssue({ titleIncludes })` to be consistent with `findPullRequests`
* Breaking: `findIssue()` and `findPullRequest()` now return null instead of empty object on find failure