### PR TITLE
Add `using` method for returning helper instance on different repo

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -503,6 +503,10 @@ function mod (githubContext, githubToken) {
 
   const repoURL = context.payload?.repository.html_url ?? `https://github.com/${context.repo.owner}/${context.repo.repo}`
 
+  function using ({ owner = context.repo.owner, repo }) {
+    return mod({ repo: { owner, repo } }, githubToken)
+  }
+  
   return {
     getCurrentUser,
     getRepoDetails,
@@ -551,7 +555,9 @@ function mod (githubContext, githubToken) {
     onRepoComment,
     onUpdatedPR,
     onWorkflowDispatch,
-    repoURL
+    repoURL,
+
+    using
   }
 }
 module.exports = mod

--- a/src/github.js
+++ b/src/github.js
@@ -506,7 +506,7 @@ function mod (githubContext, githubToken) {
   function using ({ owner = context.repo.owner, repo }) {
     return mod({ repo: { owner, repo } }, githubToken)
   }
-  
+
   return {
     getCurrentUser,
     getRepoDetails,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -112,6 +112,9 @@ interface UploadArtifactOptions {
 }
 
 interface GithubHelper {
+  // Return a new GithubHelper instance to run methods against a different repo
+  using(opts: { owner?: string, repo: string }): GithubHelper
+
   repoURL: string;
   // Gets information about the currently authenticated user (who's PAT is in use)
   getCurrentUser(): Promise<{

--- a/src/mock.js
+++ b/src/mock.js
@@ -81,7 +81,7 @@ const mock = {
   },
 
   findIssues: () => [],
-  findIssue: findIssue,
+  findIssue,
   getIssue: findIssue,
 
   updateIssue: noop,
@@ -108,6 +108,10 @@ const mock = {
   onRepoComment: noop,
   onUpdatedPR: noop,
   onWorkflowDispatch: noop,
-  repoURL: 'https://github.com/' + process.env.GITHUB_REPOSITORY
+  repoURL: 'https://github.com/' + process.env.GITHUB_REPOSITORY,
+
+  using () {
+    return mock
+  }
 }
 module.exports = () => mock

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -12,6 +12,11 @@ describe('basic usage', () => {
     assert(defBranch === 'main' || defBranch === 'master')
   })
 
+  it('test using', async function () {
+    const recentCommits = await github.using({ owner: 'extremeheat', repo: 'LXL' }).getRecentCommitsInRepo(20)
+    console.log('Recent commits in extremeheat/LXL', recentCommits)
+  })
+
   it('listing artifacts', async function () {
     const artifacts = await github.artifacts.list()
     console.log('List of Artifacts on Repo', artifacts)


### PR DESCRIPTION
Helpful for cross-repo workflows