### PR TITLE
Add getPullRequestChecks and waitForPullRequestChecks method for PR checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ interface GithubHelper {
 
   // Get full details about a PR by ID
   getPullRequest(id: number, includeComments?: boolean): Promise<FullPRData>;
+  // Returns the status of all the workflows that are running against the PR (CI/tests, other actions)
+  getPullRequestChecks(id: number): Promise<PRCheck[]>
+  // Waits for all of the PR checks to be complete (upto specified timeout), then return all the checks
+  waitForPullRequestChecks(id: number, timeout: number): Promise<PRCheck[]>
 
   updatePull(id: number, payload: { title?: string; body?: string }): Promise<void>;
   createPullRequest(title: string, body: string, fromBranch: string, intoBranch?: string): Promise<{ number: number, url: string }>;

--- a/src/github.js
+++ b/src/github.js
@@ -366,6 +366,35 @@ function mod (githubContext, githubToken) {
     }
   }
 
+  async function getPullRequestChecks (number) {
+    const { data } = await octokit.rest.checks.listForRef({
+      ...context.repo,
+      ref: `pull/${number}/head`
+    })
+    return data.check_runs.map(check => ({
+      name: check.name,
+      status: check.status,
+      conclusion: check.conclusion,
+      url: check.html_url
+    }))
+  }
+
+  async function waitForPullRequestChecks (number, maxWait = 30000) {
+    const start = Date.now()
+    let checks
+    do {
+      checks = await getPullRequestChecks(number)
+      if (checks.length) {
+        const pending = checks.filter(check => check.status === 'in_progress')
+        if (!pending.length) {
+          return checks
+        }
+      }
+      await new Promise(resolve => setTimeout(resolve, 5000))
+    } while (Date.now() - start < maxWait)
+    return checks
+  }
+
   async function createPullRequest (title, body, fromBranch, intoBranch) {
     if (!intoBranch) {
       intoBranch = await getDefaultBranch()
@@ -551,6 +580,9 @@ function mod (githubContext, githubToken) {
     findPullRequests,
     findPullRequest,
     getPullRequest,
+    getPullRequestChecks,
+    waitForPullRequestChecks,
+
     getDiffForPR,
     getDiffForCommit,
 

--- a/src/github.js
+++ b/src/github.js
@@ -379,7 +379,7 @@ function mod (githubContext, githubToken) {
     }))
   }
 
-  async function waitForPullRequestChecks (number, maxWait = 30000) {
+  async function waitForPullRequestChecks (number, maxWait = 60000) {
     const start = Date.now()
     let checks
     do {
@@ -390,7 +390,7 @@ function mod (githubContext, githubToken) {
           return checks
         }
       }
-      await new Promise(resolve => setTimeout(resolve, 5000))
+      await new Promise(resolve => setTimeout(resolve, 10000))
     } while (Date.now() - start < maxWait)
     return checks
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -41,6 +41,21 @@ type IssuePRDetail = {
   isClosed: boolean
 }
 
+type PRCheck = {
+  name: string,
+  status: "queued" | "in_progress" | "completed",
+  conclusion:
+    | "success"
+    | "failure"
+    | "neutral"
+    | "cancelled"
+    | "skipped"
+    | "timed_out"
+    | "action_required"
+    | null,
+  url: string
+}
+
 interface GithubHelper {
   // Return a new GithubHelper instance to run methods against a different repo
   using(opts: { owner?: string, repo: string }): GithubHelper
@@ -80,8 +95,12 @@ interface GithubHelper {
 
   getComments(id: number): Promise<Comment[]>;
 
-  // Get full details about a PR by ID
+  // Get full details about a PR by its number
   getPullRequest(id: number, includeComments?: boolean): Promise<FullPRData>;
+  // Returns the status of all the workflows that are running against the PR (CI/tests, other actions)
+  getPullRequestChecks(id: number): Promise<PRCheck[]>
+  // Waits for all of the PR checks to be complete (upto specified timeout), then return all the checks
+  waitForPullRequestChecks(id: number, timeout: number): Promise<PRCheck[]>
 
   updatePull(id: number, payload: { title?: string; body?: string }): Promise<void>;
   createPullRequest(title: string, body: string, fromBranch: string, intoBranch?: string): Promise<{ number: number, url: string }>;

--- a/src/mock.js
+++ b/src/mock.js
@@ -90,6 +90,9 @@ const mock = {
   findPullRequests: () => [],
   findPullRequest: noop,
   getPullRequest,
+  getPullRequestChecks: () => [],
+  waitForPullRequestChecks: noop,
+
   updatePull: noop,
   createPullRequest: () => ({ number: 420, url: 'http://example.url/420' }),
   createPullRequestReview: noop,

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -17,6 +17,12 @@ describe('basic usage', () => {
     console.log('Recent commits in extremeheat/LXL', recentCommits)
   })
 
+  it('PR checks', async function () {
+    // test on https://github.com/extremeheat/gh-helpers/pull/16
+    const checks = await github.waitForPullRequestChecks(16)
+    console.log('PR Checks for #16', checks)
+  })
+
   it('listing artifacts', async function () {
     const artifacts = await github.artifacts.list()
     console.log('List of Artifacts on Repo', artifacts)


### PR DESCRIPTION
```ts
interface GithubHelper {
...
  // Returns the status of all the workflows that are running against the PR (CI/tests, other actions)
  getPullRequestChecks(id: number): Promise<PRCheck[]>
  // Waits for all of the PR checks to be complete (upto specified timeout), then return all the checks
  waitForPullRequestChecks(id: number, timeout: number): Promise<PRCheck[]>
...
}
```
usage
```js
    const checks = await github.waitForPullRequestChecks(16)
    console.log('PR Checks for #16', checks)
```

output
```js
Checks [
  {
    name: 'build (18.x)',
    status: 'completed',
    conclusion: 'success',
    url: 'https://github.com/extremeheat/LXL/actions/runs/8711779696/job/23896640919'
  }
]
```